### PR TITLE
Add Python 3.6, drop Python 3.3.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+source = zope.contenttype
+
+[report]
+precision = 2
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError
+    self.fail
+    raise AssertionError

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .coverage
 coverage.xml
 nosetests.xml
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,19 @@ language: python
 sudo: false
 python:
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
+    - 3.6
     - pypy
-    - pypy3
+    - pypy3.5-5.8.0
 install:
-    - pip install .
+    - pip install -U pip setuptools
+    - pip install -U coverage coveralls
+    - pip install -U -e .[test]
 script:
-    - python setup.py test -q
+    - coverage run -m zope.testrunner --test-path=src
+after_success:
+    - coveralls
 notifications:
     email: false
+cache: pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,34 +1,37 @@
-Change History
-==============
+================
+ Change History
+================
 
 4.3.0 (unreleased)
-------------------
+==================
 
-- Nothing changed yet.
+- Add support for Python 3.6.
+
+- Drop support for Python 3.3.
 
 
 4.2.0 (2016-08-26)
-------------------
+==================
 
 - Add support for Python 3.5.
 
 - Drop support for Python 2.6.
 
 4.1.0 (2014-12-26)
-------------------
+==================
 
 - Add support for Python 3.4 and PyPy3.
 
 - Add support for testing on Travis.
 
 4.0.1 (2013-02-20)
-------------------
+==================
 
 - Change the file contents argument of ``guess_content_type`` from string
   to bytes.  This change has no effect on Python 2.
 
 4.0.0 (2013-02-11)
-------------------
+==================
 
 - Add some tests for better coverage.
 
@@ -39,51 +42,51 @@ Change History
 - Drop support for Python 2.4 and 2.5.
 
 3.5.5 (2011-07-27)
-------------------
+==================
 
 - Properly restore the HTML snippet detection, by looking at the entire string
   and not just its start.
 
 3.5.4 (2011-07-26)
-------------------
+==================
 
 - Restore detection of HTML snippets from 3.4 series.
 
 3.5.3 (2011-03-18)
-------------------
+==================
 
 - Add new mime types for web fonts, cache manifest and new media formats.
 
 3.5.2 (2011-02-11)
-------------------
+==================
 
 - LP #717289:  add ``video/x-m4v`` mimetype for the ``.m4v`` extension.
 
 3.5.1 (2010-03-23)
-------------------
+==================
 
 - LP #242321:  fix IndexError raised when testing strings consisting
   solely of leading whitespace.
 
 3.5.0 (2009-10-22)
-------------------
+==================
 
 - Move the implementation of ``zope.publisher.contenttype`` to
   ``zope.contenttype.parse``, moved tests along.
 
 3.4.3 (2009-12-28)
-------------------
+==================
 
 - Update mime-type for ``.js`` to be application/javascript.
 
 3.4.2 (2009-05-28)
-------------------
+==================
 
 - Add MS Office 12 types based on:
   http://www.therightstuff.de/2006/12/16/Office+2007+File+Icons+For+Windows+SharePoint+Services+20+And+SharePoint+Portal+Server+2003.aspx
 
 3.4.1 (2009-02-04)
-------------------
+==================
 
 - Improve ``text_type()``. Based on the patch from
   http://www.zope.org/Collectors/Zope/2355/
@@ -93,6 +96,6 @@ Change History
 - Add reference documentation.
 
 3.4.0 (2007-09-13)
-------------------
+==================
 
 - First stable release as an independent package.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,8 @@ include *.txt
 include tox.ini
 include bootstrap.py
 include buildout.cfg
+include .travis.yml
+include .coveragerc
 exclude coverage.xml
 
 recursive-include src *

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,19 @@
-``zope.contenttype``
-====================
+======================
+ ``zope.contenttype``
+======================
+
+.. image:: https://img.shields.io/pypi/v/zope.contenttype.svg
+        :target: https://pypi.python.org/pypi/zope.contenttype/
+        :alt: Latest release
+
+.. image:: https://img.shields.io/pypi/pyversions/zope.contenttype.svg
+        :target: https://pypi.org/project/zope.contenttype/
+        :alt: Supported Python versions
 
 .. image:: https://travis-ci.org/zopefoundation/zope.contenttype.png?branch=master
         :target: https://travis-ci.org/zopefoundation/zope.contenttype
 
-A utility module for content-type handling.
+.. image:: https://coveralls.io/repos/github/zopefoundation/zope.contenttype/badge.svg?branch=master
+        :target: https://coveralls.io/github/zopefoundation/zope.contenttype?branch=master
 
+A utility module for content-type handling.

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,5 @@ cover-min-percentage=100
 with-doctest=0
 where=src
 
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,14 @@ def read(*rnames):
 
 long_description = read('README.rst') + '\n' + read('CHANGES.rst')
 
+TESTS_REQUIRE = [
+    'zope.testrunner',
+]
+
 setup(
     name='zope.contenttype',
     version='4.3.0.dev0',
-    url='http://pypi.python.org/pypi/zope.contenttype',
+    url='http://github.com/zopefoundation/zope.contenttype',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.org',
     license='ZPL 2.1',
@@ -44,15 +48,15 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Operating System :: OS Independent',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development',
-        ],
+    ],
     description='Zope contenttype',
     long_description=long_description,
     packages=find_packages('src'),
@@ -60,6 +64,10 @@ setup(
     namespace_packages=['zope',],
     install_requires=['setuptools'],
     test_suite='zope.contenttype',
+    tests_require=TESTS_REQUIRE,
+    extras_require={
+        'test': TESTS_REQUIRE,
+    },
     include_package_data=True,
     zip_safe=False,
-    )
+)

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,1 @@
-__import__('pkg_resources').declare_namespace(__name__)
+__import__('pkg_resources').declare_namespace(__name__) # pragma: no cover

--- a/src/zope/contenttype/__init__.py
+++ b/src/zope/contenttype/__init__.py
@@ -12,6 +12,7 @@
 ##############################################################################
 """A utility module for content-type handling.
 """
+from __future__ import print_function
 import re
 import os.path
 import mimetypes
@@ -71,7 +72,7 @@ def guess_content_type(name='', body=b'', default=None):
         else:
             type = default or 'text/x-unknown-content-type'
 
-    return type.lower(), enc and enc.lower() or None
+    return type.lower(), enc.lower() if enc else None
 
 
 def add_files(filenames):
@@ -104,15 +105,12 @@ def add_files(filenames):
 here = os.path.dirname(os.path.abspath(__file__))
 add_files([os.path.join(here, "mime.types")])
 
-# Python 2/3 compatibility for testing.
-def _print(s):  # pragma: NO COVER
-    print(s)
 
 def main():
     items = mimetypes.types_map.items()
     items = sorted(items)
     for item in items:
-        _print("%s:\t%s" % item)
+        print("%s:\t%s" % item)
 
-if __name__ == '__main__': #pragma: nocover
+if __name__ == '__main__':
     main()

--- a/src/zope/contenttype/parse.py
+++ b/src/zope/contenttype/parse.py
@@ -87,16 +87,13 @@ def _parse_params(string):
 
 
 _quoted_string_match = re.compile('"(?:\\\\.|[^"\n\r\\\\])*"', re.DOTALL).match
+_token_match = re.compile("[^][ \t\n\r()<>@,;:\"/?=\\\\]+$").match
 
 def _check_token(string):
     if _token_match(string) is None:
         raise ValueError('"%s" is not a valid token' % string)
     return string
 
-def _token_match(string):
-    global _token_match
-    _token_match = re.compile("[^][ \t\n\r()<>@,;:\"/?=\\\\]+$").match
-    return _token_match(string)
 
 def _unescape(string):
     assert string[0] == '"'

--- a/src/zope/contenttype/tests/testContentTypes.py
+++ b/src/zope/contenttype/tests/testContentTypes.py
@@ -13,6 +13,7 @@
 ##############################################################################
 """Tests of the contenttypes extension mechanism.
 """
+from __future__ import print_function
 import unittest
 
 class ContentTypesTestCase(unittest.TestCase):
@@ -39,21 +40,22 @@ class ContentTypesTestCase(unittest.TestCase):
 
     def test_main(self):
         import zope.contenttype
-        _print = zope.contenttype._print
-        zope.contenttype._print = lambda s: None
+        result = []
+        zope.contenttype.print = result.append
         zope.contenttype.main()
-        zope.contenttype._print = _print
+        del zope.contenttype.print
+        self.assertTrue(result)
 
     def test_guess_content_type(self):
         from zope.contenttype import add_files
         from zope.contenttype import guess_content_type
         filename = self._getFilename('mime.types-1')
         add_files([filename])
-        ctype, encoding = guess_content_type(body=b'text file')
+        ctype, _encoding = guess_content_type(body=b'text file')
         self.assertEqual(ctype, "text/plain")
-        ctype, encoding = guess_content_type(body=b'\001binary')
+        ctype, _encoding = guess_content_type(body=b'\001binary')
         self.assertEqual(ctype, "application/octet-stream")
-        ctype, encoding = guess_content_type()
+        ctype, _encoding = guess_content_type()
         self.assertEqual(ctype, "text/x-unknown-content-type")
 
 
@@ -114,4 +116,4 @@ class ContentTypesTestCase(unittest.TestCase):
 
 
 def test_suite():
-    return unittest.makeSuite(ContentTypesTestCase)
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/src/zope/contenttype/tests/test_parse.py
+++ b/src/zope/contenttype/tests/test_parse.py
@@ -163,18 +163,18 @@ class JoinTestCase(unittest.TestCase):
         # multiple parameters given as a list maintain order:
         self.assertEqual(
             self._callFUT(("text", "plain",
-                              [("charset", "UTF-8"), ("format", "flowed")])),
+                           [("charset", "UTF-8"), ("format", "flowed")])),
             "text/plain;charset=UTF-8;format=flowed")
         self.assertEqual(
             self._callFUT(("text", "plain",
-                              [("format", "flowed"), ("charset", "UTF-8")])),
+                           [("format", "flowed"), ("charset", "UTF-8")])),
             "text/plain;format=flowed;charset=UTF-8")
 
     def test_multi_params_dict_sorted_order(self):
         # multiple parameters given as a dict are sorted by param name:
         self.assertEqual(
             self._callFUT(("text", "plain",
-                              {"charset": "UTF-8", "format": "flowed"})),
+                           {"charset": "UTF-8", "format": "flowed"})),
             "text/plain;charset=UTF-8;format=flowed")
 
     def test_params_list_quoted(self):
@@ -205,8 +205,4 @@ class JoinTestCase(unittest.TestCase):
 
 
 def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(ParseOrderedTestCase),
-        unittest.makeSuite(ParseTestCase),
-        unittest.makeSuite(JoinTestCase),
-    ))
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,20 @@
 [tox]
 envlist =
-    py27,py33,py34,py35,pypy,pypy3,coverage
+   py27,py34,py35,py36,pypy,pypy3,coverage
 
 [testenv]
 commands =
-    python setup.py -q test -q
+    zope-testrunner --test-path=src []
+deps =
+    .[test]
 
 [testenv:coverage]
 usedevelop = true
 basepython =
     python2.7
 commands =
-    nosetests --with-xunit --with-xcoverage
+    coverage run -m zope.testrunner --test-path=src
+    coverage report --fail-under=100
 deps =
-    nose
+    {[testenv]deps}
     coverage
-    nosexcover


### PR DESCRIPTION
- Badges
- Add coverage environment and coveralls
  - 100% coverage
    - Some simplifications to help that, including using
      print_function for simpler parity on Py2/Py3, and not rewriting
      the _token_match function at runtime (presumably this was to
      delay compiling a regex at import time, but other regexes are
      already being compiled now at import time, so the hit is minor)

- Using zope.testrunner for consistency with other zopefoundation packages. (This is probably not strictly necessary because this package has no other namespace dependencies so we are unlikely to see the namespace path problem.)