### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,9 @@ python:
     - 3.4
     - 3.5
     - 3.6
+    - 3.7
     - pypy
     - pypy3
-matrix:
-    include:
-        - python: "3.7"
-          dist: xenial
-          sudo: true
 install:
     - pip install -U pip setuptools
     - pip install -U coverage coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - 3.5
     - 3.6
     - 3.7
+    - 3.8
     - pypy
     - pypy3
 install:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@
 - Fix tests on Python 3.8
   (`#7 <https://github.com/zopefoundation/zope.contenttype/issues/7>`_).
 
+- Add support for Python 3.8.
+
 
 4.4 (2018-10-05)
 ================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 4.5 (unreleased)
 ================
 
-- Nothing changed yet.
+- Fix tests on Python 3.8
+  (`#7 <https://github.com/zopefoundation/zope.contenttype/issues/7>`_).
 
 
 4.4 (2018-10-05)

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Operating System :: OS Independent',

--- a/src/zope/contenttype/tests/testContentTypes.py
+++ b/src/zope/contenttype/tests/testContentTypes.py
@@ -22,6 +22,7 @@ class ContentTypesTestCase(unittest.TestCase):
         import mimetypes
         mimetypes.init()
         self._old_state = mimetypes.__dict__.copy()
+        self._old_types_count = len(self._old_state["types_map"])
 
     def tearDown(self):
         import mimetypes
@@ -31,7 +32,7 @@ class ContentTypesTestCase(unittest.TestCase):
     def _check_types_count(self, delta):
         import mimetypes
         self.assertEqual(len(mimetypes.types_map),
-                         len(self._old_state["types_map"]) + delta)
+                         self._old_types_count + delta)
 
     def _getFilename(self, name):
         import os.path

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-   py27,py34,py35,py36,py37,pypy,pypy3,coverage
+   py27,py34,py35,py36,py37,py38,pypy,pypy3,coverage
 
 [testenv]
 commands =
@@ -11,7 +11,7 @@ deps =
 [testenv:coverage]
 usedevelop = true
 basepython =
-    python3.7
+    python3.8
 commands =
     coverage run -m zope.testrunner --test-path=src
     coverage report --fail-under=100


### PR DESCRIPTION
This follows up on @mgedmin's detective work in #7; I think this is about the simplest possible tweak to tolerate recent changes to `mimetypes`.