### PR TITLE
Call `mimetypes.guess_type` with parameter `strict=False`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,12 @@
 
 - Add some more MIME types and extensions.
 
+- Call ``mimetypes.guess_type`` with parameter ``strict=False``. This
+  recognizes a few more content types related to ``midi``, ``pict``,
+  ``xul`` and ``rtf``;
+  for details, see
+  `#14 <https://github.com/zopefoundation/zope.contenttype/issues/7>`_.
+
 
 5.0 (2023-03-27)
 ================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 5.1 (unreleased)
 ================
 
-- Nothing changed yet.
+- Add some more MIME types and extensions.
 
 
 5.0 (2023-03-27)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,6 @@
 5.2 (unreleased)
 ================
 
-- Add some more MIME types and extensions.
-
 - Call ``mimetypes.guess_type`` with parameter ``strict=False``. This
   recognizes a few more content types related to ``midi``, ``pict``,
   ``xul`` and ``rtf``;

--- a/src/zope/contenttype/__init__.py
+++ b/src/zope/contenttype/__init__.py
@@ -74,7 +74,7 @@ def guess_content_type(name='', body=b'', default=None):
     # Attempt to determine the content type (and possibly
     # content-encoding) based on an an object's name and
     # entity body.
-    type, enc = mimetypes.guess_type(name)
+    type, enc = mimetypes.guess_type(name, strict=False)
     if type is None:
         if body:
             if find_binary(body) is not None:

--- a/src/zope/contenttype/mime.types
+++ b/src/zope/contenttype/mime.types
@@ -1,48 +1,58 @@
-application-x-cdf               cdf
+application/javascript          js
 application/msword              doc dot wiz
 application/pdf                 pdf
 application/pkcs7-mime          p7c
 application/vnd.mozilla.xul+xml xul
 application/vnd.ms-excel        xlb xls
+application/vnd.ms-excel.addin.macroEnabled.12                             xlam
+application/vnd.ms-excel.sheet.binary.macroEnabled.12                      xlsb
+application/vnd.ms-excel.sheet.macroEnabled.12                             xlsm
+application/vnd.ms-excel.template.macroEnabled.12                          xltm
 application/vnd.ms-fontobject   eot
 application/vnd.ms-powerpoint   pot ppa pps ppt pwz
-application/javascript          js
+application/vnd.ms-powerpoint.addin.macroEnabled.12                        ppam
+application/vnd.ms-powerpoint.presentation.macroEnabled.12                 pptm
+application/vnd.ms-powerpoint.slideshow.macroEnabled.12                    ppsm
+application/vnd.ms-powerpoint.template.macroEnabled.12                     potm
+application/vnd.ms-word.document.macroEnabled.12                           docm
+application/vnd.ms-word.template.macroEnabled.12                           dotm
+application/vnd.openxmlformats-officedocument.presentationml.presentation  pptx
+application/vnd.openxmlformats-officedocument.presentationml.slideshow     ppsx
+application/vnd.openxmlformats-officedocument.presentationml.template      potx
+application/vnd.openxmlformats-officedocument.spreadsheetml.sheet          xlsx
+application/vnd.openxmlformats-officedocument.spreadsheetml.template       xltx
+application/vnd.openxmlformats-officedocument.wordprocessingml.document    docx
+application/vnd.openxmlformats-officedocument.wordprocessingml.template    dotx
+application/x-cdf               cdf
 application/x-font-woff         woff
+application/x-javascript        js
 application/x-pkcs12            p12 pfx
 application/x-pn-realaudio      ram
 audio/mpeg                      mp3
 audio/x-pn-realaudio            ra
 font/opentype                   otf
 font/truetype                   ttf
+image/jp2                       jp2
+image/jpeg2000                  jp2
+image/jpeg2000-image            jp2
+image/jpx                       jpx
 image/pict                      pct pic pict
 image/svg+xml                   svg svgz
+image/svg+xml-compressed        svgz
 image/vnd.microsoft.icon        ico
 image/webp                      webp
+image/x-icon                    ico
+image/x-jpeg2000-image          jp2
 message/rfc822                  eml nws mht mhtml
 text/cache-manifest             manifest
 text/css                        css
+text/html                       html
+text/javascript                 js
 text/plain                      bat c h pl ksh
 text/x-vcard                    vcf
 text/xml                        xml xsl
 video/mp4                       mp4
-video/ogg                       ogv
 video/mpeg                      m1v mpa
+video/ogg                       ogv
 video/webm                      webm
 video/x-m4v                     m4v
-application/vnd.ms-word.document.macroEnabled.12                           docm
-application/vnd.openxmlformats-officedocument.wordprocessingml.document    docx
-application/vnd.ms-word.template.macroEnabled.12                           dotm
-application/vnd.openxmlformats-officedocument.wordprocessingml.template    dotx
-application/vnd.ms-powerpoint.template.macroEnabled.12                     potm
-application/vnd.openxmlformats-officedocument.presentationml.template      potx
-application/vnd.ms-powerpoint.addin.macroEnabled.12                        ppam
-application/vnd.ms-powerpoint.slideshow.macroEnabled.12                    ppsm
-application/vnd.openxmlformats-officedocument.presentationml.slideshow     ppsx
-application/vnd.ms-powerpoint.presentation.macroEnabled.12                 pptm
-application/vnd.openxmlformats-officedocument.presentationml.presentation  pptx
-application/vnd.ms-excel.addin.macroEnabled.12                             xlam
-application/vnd.ms-excel.sheet.binary.macroEnabled.12                      xlsb
-application/vnd.ms-excel.sheet.macroEnabled.12                             xlsm
-application/vnd.openxmlformats-officedocument.spreadsheetml.sheet          xlsx
-application/vnd.ms-excel.template.macroEnabled.12                          xltm
-application/vnd.openxmlformats-officedocument.spreadsheetml.template       xltx

--- a/src/zope/contenttype/tests/testContentTypes.py
+++ b/src/zope/contenttype/tests/testContentTypes.py
@@ -59,6 +59,8 @@ class ContentTypesTestCase(unittest.TestCase):
         self.assertEqual(ctype, "application/octet-stream")
         ctype, _encoding = guess_content_type()
         self.assertEqual(ctype, "text/x-unknown-content-type")
+        ctype, _encoding = guess_content_type("abc.rtf")
+        self.assertEqual(ctype, "application/rtf")
 
     def test_add_one_file(self):
         from zope.contenttype import add_files


### PR DESCRIPTION
Fixes #14.
The PR calls `mimetypes.guess_type` with parameter `strict=False`.
This recognizes a few more content types related to `midi`, `pict`, `xul` and `rtf`.